### PR TITLE
对 Github 外部仓库的代码片段使用永久链接

### DIFF
--- a/md/02使用线程.md
+++ b/md/02使用线程.md
@@ -477,7 +477,7 @@ void test(){
   }
   ```
 
-  主线程延时 3 秒，这个传入了一个临时对象 `seconds` ，它是模板 [`std::chrono::duration`](https://zh.cppreference.com/w/cpp/chrono/duration) 的别名，以及还有很多其他的时间类型，都基于这个类。说实话挺麻烦的，如果您支持 C++14，建议使用[时间字面量](https://zh.cppreference.com/w/cpp/symbol_index/chrono_literals)，在 [`std::chrono_literals`](https://github.com/microsoft/STL/blob/main/stl/inc/__msvc_chrono.hpp#L742-L804) 命名空间中。我们可以改成下面这样：
+  主线程延时 3 秒，这个传入了一个临时对象 `seconds` ，它是模板 [`std::chrono::duration`](https://zh.cppreference.com/w/cpp/chrono/duration) 的别名，以及还有很多其他的时间类型，都基于这个类。说实话挺麻烦的，如果您支持 C++14，建议使用[时间字面量](https://zh.cppreference.com/w/cpp/symbol_index/chrono_literals)，在 [`std::chrono_literals`](https://github.com/microsoft/STL/blob/8e2d724cc1072b4052b14d8c5f81a830b8f1d8cb/stl/inc/__msvc_chrono.hpp#L718-L780) 命名空间中。我们可以改成下面这样：
 
   ```cpp
   using namespace std::chrono_literals;

--- a/md/03共享数据.md
+++ b/md/03共享数据.md
@@ -127,7 +127,7 @@ void f() {
 }
 ```
 
-那么问题来了，`std::lock_guard` 是如何做到的呢？它是怎么实现的呢？首先顾名思义，这是一个“管理类”模板，用来管理互斥量的上锁与解锁，我们来看它的 [MSVC 实现](https://github.com/microsoft/STL/blob/main/stl/inc/mutex#L452-L473)：
+那么问题来了，`std::lock_guard` 是如何做到的呢？它是怎么实现的呢？首先顾名思义，这是一个“管理类”模板，用来管理互斥量的上锁与解锁，我们来看它的 [MSVC 实现](https://github.com/microsoft/STL/blob/8e2d724cc1072b4052b14d8c5f81a830b8f1d8cb/stl/inc/mutex#L452-L473)：
 
 ```cpp
 _EXPORT_STD template <class _Mutex>

--- a/md/详细分析/02scoped_lock源码解析.md
+++ b/md/详细分析/02scoped_lock源码解析.md
@@ -4,7 +4,7 @@
 
 这会涉及到不少的模板技术，这没办法，就如同我们先前聊 [`std::thread` 的构造与源码分析](01thread的构造与源码解析.md)最后说的：“**不会模板，你阅读标准库源码，是无稽之谈**”。
 
-我们还是一样的，以 MSVC STL 的实现的 [`std::scoped_lock`](https://github.com/microsoft/STL/blob/main/stl/inc/mutex#L476-L528) 代码进行讲解，不用担心，我们也查看了 [`libstdc++`](https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/include/std/mutex#L743-L802) 、[`libc++`](https://github.com/llvm/llvm-project/blob/main/libcxx/include/mutex#L424-L488)的实现，并没有太多区别，更多的是一些风格上的。而且个人觉得 MSVC 的实现是最简单直观的。
+我们还是一样的，以 MSVC STL 的实现的 [`std::scoped_lock`](https://github.com/microsoft/STL/blob/8e2d724cc1072b4052b14d8c5f81a830b8f1d8cb/stl/inc/mutex#L476-L528) 代码进行讲解，不用担心，我们也查看了 [`libstdc++`](https://github.com/gcc-mirror/gcc/blob/7a01cc711f33530436712a5bfd18f8457a68ea1f/libstdc%2B%2B-v3/include/std/mutex#L743-L802) 、[`libc++`](https://github.com/llvm/llvm-project/blob/7ac7d418ac2b16fd44789dcf48e2b5d73de3e715/libcxx/include/mutex#L424-L488)的实现，并没有太多区别，更多的是一些风格上的。而且个人觉得 MSVC 的实现是最简单直观的。
 
 ## `std:scoped_lock` 的数据成员
 


### PR DESCRIPTION
如题，见 Mq-b/Modern-Cpp-templates-tutorial#33。 MSVC STL 中的代码已经进行过一些移动了。