### PR TITLE
继续对 Github 外部仓库的代码片段使用永久链接

### DIFF
--- a/md/03共享数据.md
+++ b/md/03共享数据.md
@@ -542,7 +542,7 @@ void _Validate() const { // check if the mutex can be locked
 }
 ```
 
-满足第二个 if，因为 `_Owns` 为 `true` 所以抛出异常，别的标准库也都有[类似设计](https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/include/bits/unique_lock.h#L141-L144)。很诡异的设计对吧，正常。除非我们写成：
+满足第二个 if，因为 `_Owns` 为 `true` 所以抛出异常，别的标准库也都有[类似设计](https://github.com/gcc-mirror/gcc/blob/3e3d115c946944c81d8231dfbe778d4dae26cbb7/libstdc%2B%2B-v3/include/bits/unique_lock.h#L141-L144)。很诡异的设计对吧，正常。除非我们写成：
 
 ```cpp
 lock.mutex()->lock();

--- a/md/详细分析/01thread的构造与源码解析.md
+++ b/md/详细分析/01thread的构造与源码解析.md
@@ -154,7 +154,7 @@ void _Start(_Fn&& _Fx, _Args&&... _Ax) {
 
 ## 总结
 
-需要注意，libstdc++ 和 libc++ 可能不同，就比如它们 64 位环境下 `sizeof(std::thread)` 的结果就可能是 **8**。libstdc++ 的实现只[保有一个 `std::thread::id`](https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/include/bits/std_thread.h#L123)。[参见](https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/include/bits/std_thread.h#L81-L85)。不过实测 gcc 不管是 `win32` 还是 `POSIX` 线程模型，线程对象的大小都是 8，宏 `_GLIBCXX_HAS_GTHREADS` 的值都为 1（[GThread](https://docs.gtk.org/glib/struct.Thread.html)）。
+需要注意，libstdc++ 和 libc++ 可能不同，就比如它们 64 位环境下 `sizeof(std::thread)` 的结果就可能是 **8**。libstdc++ 的实现只[保有一个 `std::thread::id`](https://github.com/gcc-mirror/gcc/blob/3e3d115c946944c81d8231dfbe778d4dae26cbb7/libstdc%2B%2B-v3/include/bits/std_thread.h#L123)。[参见](https://github.com/gcc-mirror/gcc/blob/3e3d115c946944c81d8231dfbe778d4dae26cbb7/libstdc%2B%2B-v3/include/bits/std_thread.h#L81-L85)。不过实测 gcc 不管是 `win32` 还是 `POSIX` 线程模型，线程对象的大小都是 8，宏 `_GLIBCXX_HAS_GTHREADS` 的值都为 1（[GThread](https://docs.gtk.org/glib/struct.Thread.html)）。
 
 > ```cpp
 >  class thread


### PR DESCRIPTION
见 #2。不确定是漏了改还是后来没注意。