### PR TITLE
避免多次 `load` 同一个 `atomic<shared_ptr>`

### DIFF
--- a/md/05内存模型与原子操作.md
+++ b/md/05内存模型与原子操作.md
@@ -493,8 +493,8 @@ void writer() {
 
 void reader() {
     for (int i = 0; i < 10; ++i) {
-        if (data.load()) {
-            std::cout << "读取线程值: " << data.load()->get_value() << std::endl;
+        if (auto sp = data.load()) {
+            std::cout << "读取线程值: " << sp->get_value() << std::endl;
         }
         else {
             std::cout << "没有读取到数据" << std::endl;
@@ -504,7 +504,7 @@ void reader() {
 }
 ```
 
-很显然，这是线程安全的，`store` 是原子操作，而 `data.load()->get_value()` 只是个读取操作。
+很显然，这是线程安全的，`store` 是原子操作，而 `sp->get_value()` 只是个读取操作。
 
 我知道，你肯定会想着：*能不能调用 `load()` 成员函数原子地返回底层的 `std::shared_ptr` 再调用 `swap` 成员函数？*
 


### PR DESCRIPTION
两次 `load` 结果可能是不同的，这会导致用第一次 `load` 的结果判断没有意义。如果 `data` 可能被修改为空，则 `data.load()->get_value()` 可能造成空指针解引用。